### PR TITLE
Fix module acquisition

### DIFF
--- a/ATG-PS-Functions.txt
+++ b/ATG-PS-Functions.txt
@@ -386,13 +386,22 @@ Function Invoke-Win10Decrap {
 Function Expand-Terminal {
 	mode con: cols=160 lines=120
 }
+Function Import-ATGPS {
+	[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
+	$Destination = $Env:temp + "\ATGPS.psm1"
+	(New-Object System.Net.WebClient).DownloadString('https://git.io/ATGPS') | Out-File -FilePath $Destination
+	Import-Module $Destination -Global -PassThru -Force | Out-Null
+}
 
-# Print out functions from this file
+# Import our functions
+Import-ATGPS
+
+# List imported functions from ATGPS
 Write-Host `n====================================================
-Write-Host The below functions are now loaded and ready to use:
+Write-Host "The below functions are now loaded and ready to use:"
 Write-Host ====================================================`n
 
-(Get-Module ATGPS).ExportedFunctions.Values | Format-Wide -Column 3
+Get-Command -Module ATGPS | Format-Wide -Column 3
 
 Write-Host `n====================================================
 Write-Host "Type: 'Help <function name> -Detailed' for more info"

--- a/ATG-PS-Functions.txt
+++ b/ATG-PS-Functions.txt
@@ -386,23 +386,34 @@ Function Invoke-Win10Decrap {
 Function Expand-Terminal {
 	mode con: cols=160 lines=120
 }
-Function Import-ATGPS {
+
+$ATGPSModulePath = $Env:temp + "\ATGPS.psm1"
+
+If (!(Test-Path $ATGPSModulePath)) {
+	# download this file as a module and import it
 	[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
-	$Destination = $Env:temp + "\ATGPS.psm1"
-	(New-Object System.Net.WebClient).DownloadString('https://git.io/ATGPS') | Out-File -FilePath $Destination
-	Import-Module $Destination -Global -PassThru -Force | Out-Null
+	#(New-Object System.Net.WebClient).DownloadString('https://git.io/ATGPS') | Out-File -FilePath $ATGPSModulePath
+
+	# temp path for testing:
+	(New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/AmbitionsTechnologyGroup/ATG-PS-Functions/fix-module-acquisition/ATG-PS-Functions.txt') | Out-File -FilePath $ATGPSModulePath
+	## END TESTING
+    
+	Import-Module $ATGPSModulePath -Global -Force | Out-Null
+} 
+
+If (Get-Module -Name ATGPS -ErrorAction SilentlyContinue){
+	# List imported functions from ATGPS
+	Write-Host `n====================================================
+	Write-Host "The below functions are now loaded and ready to use:"
+	Write-Host ====================================================
+
+	Get-Command -Module ATGPS | Format-Wide -Column 3
+
+	Write-Host ====================================================
+	Write-Host "Type: 'Help <function name> -Detailed' for more info"
+	Write-Host ====================================================`n
 }
 
-# Import our functions
-Import-ATGPS
-
-# List imported functions from ATGPS
-Write-Host `n====================================================
-Write-Host "The below functions are now loaded and ready to use:"
-Write-Host ====================================================`n
-
-Get-Command -Module ATGPS | Format-Wide -Column 3
-
-Write-Host `n====================================================
-Write-Host "Type: 'Help <function name> -Detailed' for more info"
-Write-Host ====================================================`n
+If (Test-Path $ATGPSModulePath) {
+	Remove-Item $ATGPSModulePath -Force
+}

--- a/ATG-PS-Functions.txt
+++ b/ATG-PS-Functions.txt
@@ -392,12 +392,7 @@ $ATGPSModulePath = $Env:temp + "\ATGPS.psm1"
 If (!(Test-Path $ATGPSModulePath)) {
 	# download this file as a module and import it
 	[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
-	#(New-Object System.Net.WebClient).DownloadString('https://git.io/ATGPS') | Out-File -FilePath $ATGPSModulePath
-
-	# temp path for testing:
-	(New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/AmbitionsTechnologyGroup/ATG-PS-Functions/fix-module-acquisition/ATG-PS-Functions.txt') | Out-File -FilePath $ATGPSModulePath
-	## END TESTING
-    
+	(New-Object System.Net.WebClient).DownloadString('https://git.io/ATGPS') | Out-File -FilePath $ATGPSModulePath
 	Import-Module $ATGPSModulePath -Global -Force | Out-Null
 } 
 


### PR DESCRIPTION
@RCShoemaker Whew this one was a doozey.  I worked on fixing the original method used to load the functions:

```powershell
(New-Object Net.WebClient).DownloadString('https://git.io/ATGPS') | Invoke-Expression
#   --OR--
Invoke-WebRequest -Uri git.io/ATGPS -UseBasicParsing | Invoke-Expression
```
It's using your method of importing the module so that we can easily list the functions provided by this script.  That dang 'Import-Module' causes some weird recursive invocation of everything, but this gets around it.

If you want to test this, you'll have to checkout one previous commit in the branch so that it uses the correct URL's that point to itself (instead of downloading from the master branch; the latest commit in this branch fixes the URL's to point back to master so that it will work when merged to master).

To test things, do this:

```
git pull
git checkout fix-module-acquisition
git checkout 2d5af72
```

Also, to run the script initially, you'll have to make sure you don't have ATGPS.psm1 in $ENV:temp.  Otherwise, it won't work until you run it again.

### EDIT:
Actually that testing won't work...  you'd have to do some shenanigans on line 395 to point the URL to commit 2d5af72, which you could do theoretically....   let me know if you want to test this and I can show you what I mean ;)