### PR TITLE
Add Get-IdleTime function

### DIFF
--- a/ATG-PS-Functions.txt
+++ b/ATG-PS-Functions.txt
@@ -496,13 +496,11 @@ function Get-IdleTime
                     ForEach-Object {($_ -replace '\s{2,}', ',').Trim()} |
                     ConvertFrom-Csv -Header $Header |
                     ForEach-Object {
-                        if ($_.IdleTime -eq 'none')
+                        if ($_.IdleTime -eq 'none' -Or '.')
                             {
-                            $IdleTime = "Keyboard/Mouse ACTIVE"
-                            }
-                            else
-                            {
-                            $IdleTime = [timespan]$_.IdleTime
+                            	$IdleTime = "Keyboard/Mouse Currently Active"
+                            } else {
+                            	$IdleTime = [timespan]$_.IdleTime
                             }
                         [PSCustomObject]@{
                             ComputerName = $CN_Item

--- a/ATG-PS-Functions.txt
+++ b/ATG-PS-Functions.txt
@@ -470,6 +470,85 @@ Function Get-ThunderBolt {
 	}
 }
 
+function Get-IdleTime
+    {
+    [CmdletBinding()]
+    Param (
+        [Parameter ()]
+            [string[]]
+            $ComputerName = 'localhost'
+        )
+
+    begin
+        {
+        $Header = 'UserName','SessionName','ID','State','IdleTime','LogonTime'
+        $No_Connection = '-- No Connection --'
+        }
+
+    process
+        {
+        foreach ($CN_Item in $ComputerName)
+            {
+            if (Test-Connection -ComputerName $CN_Item -Count 1 -Quiet)
+                {
+                quser /server:$CN_Item |
+                    Select-Object -Skip 1 |
+                    ForEach-Object {($_ -replace '\s{2,}', ',').Trim()} |
+                    ConvertFrom-Csv -Header $Header |
+                    ForEach-Object {
+                        if ($_.IdleTime -eq 'none')
+                            {
+                            $IdleTime = "Keyboard/Mouse ACTIVE"
+                            }
+                            else
+                            {
+                            $IdleTime = [timespan]$_.IdleTime
+                            }
+                        [PSCustomObject]@{
+                            ComputerName = $CN_Item
+                            UserName = $_.UserName
+                            SessionName = $_.SessionName
+                            ID = $_.ID
+                            State = $_.State
+                            IdleTime = $IdleTime
+                            LogonTime = [datetime]$_.LogonTime
+                            }
+                        }
+                }
+                else
+                {
+                [PSCustomObject]@{
+                    ComputerName = $CN_Item
+                    UserName = $No_Connection
+                    SessionName = $No_Connection
+                    ID = $No_Connection
+                    State = $No_Connection
+                    IdleTime = $No_Connection
+                    LogonTime = $No_Connection
+                    }
+                }
+            } # end >> foreach ($CN_Item in $ComputerName)
+        } # end >> process {}
+
+    end {}
+
+	<#
+	.DESCRIPTION
+		Checks active logon sessions to check for idle time and time of logon
+
+	.LINK
+		https://www.reddit.com/r/PowerShell/comments/8r56tr/getting_idle_time_for_logged_on_domain_users#t1_e0oja92
+
+	.PARAMETER ComputerName
+		A comma-separated list of hostnames and/or IP Addresses; must have admin access to all computers.  Default is 'localhost'.
+
+	.EXAMPLE
+		Get-IdleTime
+		Get-IdleTime -ComputerName 10.0.0.55,192.168.50.78,SERVER01
+	#>
+
+	} # end >> function Get-IdleTime
+
 Function Install-AppDefaults {
 	Write-Host "Downloading App Defaults"
 	New-Item -ItemType Directory -Force -Path C:\Ambitions\ITS247Agent

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ We are using a **function-based system**. There are 2 ways to load the functions
 **Run _either_:**
 ```powershell
 $progressPreference = 'silentlyContinue' #If running from a LogMeIn terminal
-iwr tinyurl.com/get-atgps -usebasicparsing | iex
+iwr tinyurl.com/get-atgps -useb | iex
 ```
 
 **--OR--**
@@ -16,7 +16,8 @@ iwr tinyurl.com/get-atgps -usebasicparsing | iex
 ```powershell
 IEX(new-object net.webclient).downloadstring('https://git.io/atgPS')
 
-# note that this may not work if SSL is not enabled in PowerShell; use the above tinyurl method for http
+# note that this may not work if SSL is not enabled in PowerShell.
+# Use the above tinyurl method for http
 ```
 
 ### 2) Browser method: ###
@@ -45,9 +46,10 @@ Enable-O365AuditLog
 Enable-Sleep                    
 Enable-SSL                      
 Expand-Terminal                 
-Get-ADUserPassExpirations       
-Get-ATGPS                       
-Get-DiskUsage                   
+Get-ADUserPassExpirations
+Get-ATGPS
+Get-DiskUsage
+Get-IdleTime
 Get-ThunderBolt                 
 Install-AppDefaults             
 Install-Choco                   


### PR DESCRIPTION
Sir Ryan,

The main reason I'm adding this is that the CW Control platform doesn't have the equivalent of LMI's "active user" info on the dashboard, so you don't know if a computer is in use before you take control.  It's easy enough to just launch backstage and just run 'quser', but this might help too.

I totally plagiarized this from a reddit thread (see the link in the function description; credit to u/Lee_Dailey).  Wanted to run it by you before we merge into master.

Is there any merit to using the [begin,process,end] statements in there, or is that just more overhead that we don't need?