### PR TITLE
Refactor Get-ListeningPorts

### DIFF
--- a/Functions/ATG-PS-Get.txt
+++ b/Functions/ATG-PS-Get.txt
@@ -270,17 +270,41 @@ Function Get-ListeningPorts {
 
 	.SYNOPSIS
 		Checks for processes that are listening on an open port. Useful for troubleshooting firewall issues.
+		For svchost.exe processes, identifies the associated service with the listening port.
 
 	 .EXAMPLE
 		Get-ListeningPorts
+
+	.EXAMPLE
+		Get-ListeningPorts -IncludeIp6
+
+	.PARAMETER IncludeIp6
+		Include this switch to include the IPv6 adapter addresses that have listening ports
 
 	.LINK
 		https://azega.org/list-open-ports-using-powershell/
 
 	#>
 
-	get-nettcpconnection | where {($_.State -eq "Listen") -and ($_.RemoteAddress -eq "0.0.0.0")} | select LocalPort,@{Name="Process";Expression={(Get-Process -Id $_.OwningProcess).ProcessName}},LocalAddress,State | Sort LocalPort
+	Param(
+		[Parameter(Mandatory=$false)]
+		[Switch]$IncludeIp6
+    )
 
+	$IpAddresses = (Get-NetIPAddress).IPAddress | Where-Object { $_ -notmatch "::" }
+	$IpAddresses += "0.0.0.0"
+
+	If ($IncludeIp6) { $IpAddresses += "::" }
+
+	Get-NetTcpConnection | Where-Object { ($_.State -eq "Listen") -and ( $IpAddresses -contains $_.LocalAddress) } | `
+		Select-Object LocalAddress,
+					  LocalPort,
+					  @{Name="Process Name";Expression={(Get-Process -Id $_.OwningProcess).ProcessName}},
+					  @{Name="Service Name";Expression={ If ((Get-Process -Id $_.OwningProcess).ProcessName -eq "svchost") {
+						  $p = $_.OwningProcess
+						  (Get-WmiObject Win32_Service | Where-Object {$_.ProcessId -eq $p}).Name
+					  } Else {$null} }},
+					  State | Sort LocalPort | Format-Table
 }
 
 Function Get-LoginHistory {


### PR DESCRIPTION
Whew this one is a doozy; I love this function so I thought I'd try to give it a little more pizzazz.  A few things:

# Local vs. Remote Addresses
It doesn't make much sense to me to filter for listening ports based on the RemoteAddress of 0.0.0.0; local listening ports should refer to local addresses.

Azega's original that selects ports where `RemoteAddress -eq 0.0.0.0` is very weird, the `Get-NetTcpConnection` cmdlet shows the RemoteAddress as being 0.0.0.0, but in reality, a listener doesn't actually yet have a RemoteAddress until a connection comes in and creates a new `ESTABLISHED` connection.

By default, my update will not show listening ports for IPv6 addresses, but can be added by including the `-IncludeIp6` switch:

```powershell
Get-ListeningPorts -IncludeIp6
```

# Processes and Services
I also added a (perhaps overly) complicated Expression to include a custom property that shows the _Service Name_, but **ONLY IF** the process name of the listening port is `svchost.exe`.

This to me is super helpful because it's weird tracking down which service is listening on a port, but this does a nice job of it (notice the service for LocalPort 3389 shows "TermService"):

```powershell
PS C:\> Get-ListeningPorts

LocalAddress   LocalPort Process Name       Service Name           State
------------   --------- ------------       ------------           -----
127.0.0.1             53 dnscrypt-proxy                           Listen
0.0.0.0              135 svchost            {RpcEptMapper, RpcSs} Listen
[snip]
0.0.0.0             3389 svchost            TermService           Listen
0.0.0.0             5040 svchost            CDPSvc                Listen
0.0.0.0             5120 STSchedEx                                Listen
127.0.0.1          18313 EndPointClassifier                       Listen
0.0.0.0            49664 lsass                                    Listen
0.0.0.0            49665 wininit                                  Listen
0.0.0.0            49666 svchost            EventLog              Listen
0.0.0.0            49667 svchost            Schedule              Listen
0.0.0.0            49668 svchost            SessionEnv            Listen
0.0.0.0            49669 spoolsv                                  Listen
0.0.0.0            49670 lsass                                    Listen
127.0.0.1          52887 emacs                                    Listen
127.0.0.1          53219 vpnagent                                 Listen
0.0.0.0            53579 svchost            PolicyAgent           Listen
[snip]
127.0.0.1          62722 acumbrellaagent                          Listen
127.0.0.1          64591 jhi_service                              Listen
```