### PR TITLE
add .gitattributes to define language (as PowerShell)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+Functions/*.txt linguist-language=PowerShell


### PR DESCRIPTION
Uses the proper GitHub method for declaring the language for the .txt files as PowerShell.  This only affects syntax highlighting for all *.txt files within the Functions/ folder.

Helps with readability when you're viewing in GitHub!

For an example, see the [ATG-PS-Get.txt](https://github.com/tobraha/ATG-PS-Functions/blob/develop/Functions/ATG-PS-Get.txt) file in my repository.